### PR TITLE
Fix/apollo client import

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "devDependencies": {
     "@actions/core": "^1.9.1",
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.0",
     "@metamask/eth-sig-util": "^4.0.1",
     "@subql/contract-sdk": "^0.10.2-26",
     "@types/jest": "^28.1.6",

--- a/packages/apollo-links/src/auth-link/authLink.ts
+++ b/packages/apollo-links/src/auth-link/authLink.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ApolloLink, FetchResult, NextLink, Observable, Operation } from '@apollo/client';
+import { ApolloLink, FetchResult, NextLink, Observable, Operation } from '@apollo/client/core';
 import { signTypedData, SignTypedDataVersion } from '@metamask/eth-sig-util';
 import jwt_decode from 'jwt-decode';
 import axios from 'axios';

--- a/packages/network-clients/package.json
+++ b/packages/network-clients/package.json
@@ -10,7 +10,7 @@
     "build": "yarn codegen-gql && tsc -b"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.0",
     "@ethersproject/bignumber": "^5.7.0",
     "axios": "^0.27.2",
     "buffer": "^6.0.3",
@@ -30,7 +30,7 @@
     "typescript": "^4.6.4"
   },
   "peerDependencies": {
-    "@subql/contract-sdk": "^0.10.2-26",
+    "@subql/contract-sdk": "^0.10.2",
     "ipfs-http-client": "^53.0.1"
   }
 }

--- a/packages/network-clients/src/graphql/agreements.ts
+++ b/packages/network-clients/src/graphql/agreements.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const SERVICE_AGREEMENT_FIELDS = gql`
   fragment ServiceAgreementFields on ServiceAgreement {

--- a/packages/network-clients/src/graphql/delegations.ts
+++ b/packages/network-clients/src/graphql/delegations.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const GET_INDEXER_DELEGATORS = gql`
   query GetIndexerDelegators($id: String!, $offset: Int) {

--- a/packages/network-clients/src/graphql/deployments.ts
+++ b/packages/network-clients/src/graphql/deployments.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const GET_DEPLOYMENT = gql`
   query GetDeployment($deploymentId: String!) {

--- a/packages/network-clients/src/graphql/indexers.ts
+++ b/packages/network-clients/src/graphql/indexers.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const INDEXER_FIELDS = gql`
   fragment IndexerFields on Indexer {

--- a/packages/network-clients/src/graphql/offers.ts
+++ b/packages/network-clients/src/graphql/offers.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const OFFER_FIELDS = gql`
   fragment OfferFields on Offer {

--- a/packages/network-clients/src/graphql/plans.ts
+++ b/packages/network-clients/src/graphql/plans.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const PLAN_TEMPLATE_FIELDS = gql`
   fragment PlanTemplateFields on PlanTemplate {

--- a/packages/network-clients/src/graphql/project.ts
+++ b/packages/network-clients/src/graphql/project.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const PROJECT_FIELDS = gql`
   fragment ProjectFields on Project {

--- a/packages/network-clients/src/graphql/staking.ts
+++ b/packages/network-clients/src/graphql/staking.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const GET_WITHDRAWLS = gql`
   query GetWithdrawls($delegator: String!, $offset: Int) {

--- a/packages/react-hooks/src/graphql/agreements.ts
+++ b/packages/react-hooks/src/graphql/agreements.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const SERVICE_AGREEMENT_FIELDS = gql`
   fragment ServiceAgreementFields on ServiceAgreement {

--- a/packages/react-hooks/src/graphql/delegations.ts
+++ b/packages/react-hooks/src/graphql/delegations.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const GET_INDEXER_DELEGATORS = gql`
   query GetIndexerDelegators($id: String!, $offset: Int) {

--- a/packages/react-hooks/src/graphql/deployments.ts
+++ b/packages/react-hooks/src/graphql/deployments.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const GET_DEPLOYMENT = gql`
   query GetDeployment($deploymentId: String!) {

--- a/packages/react-hooks/src/graphql/indexers.ts
+++ b/packages/react-hooks/src/graphql/indexers.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const INDEXER_FIELDS = gql`
   fragment IndexerFields on Indexer {

--- a/packages/react-hooks/src/graphql/offers.ts
+++ b/packages/react-hooks/src/graphql/offers.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const OFFER_FIELDS = gql`
   fragment OfferFields on Offer {

--- a/packages/react-hooks/src/graphql/plans.ts
+++ b/packages/react-hooks/src/graphql/plans.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const PLAN_TEMPLATE_FIELDS = gql`
   fragment PlanTemplateFields on PlanTemplate {

--- a/packages/react-hooks/src/graphql/project.ts
+++ b/packages/react-hooks/src/graphql/project.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const PROJECT_FIELDS = gql`
   fragment ProjectFields on Project {

--- a/packages/react-hooks/src/graphql/staking.ts
+++ b/packages/react-hooks/src/graphql/staking.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export const GET_WITHDRAWLS = gql`
   query GetWithdrawls($delegator: String!, $offset: Int) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,25 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
+"@apollo/client@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.0.tgz#1c26a04488f45b3a4779fa2562e4b706402cb876"
+  integrity sha512-hp4OvrH1ZIQACRYcIrh/C0WFnY7IM7G6nlTpC8DSTEWxfZQ2kvpvDY0I/hYmCs0oAVrg26g3ANEdOzGWTcYbPg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/context" "^0.7.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    response-iterator "^0.2.6"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@apollo/federation@0.27.0":
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/@apollo/federation/-/federation-0.27.0.tgz#2ee13b28cff94817ff07bb02215aa764d8becba3"
@@ -2825,6 +2844,13 @@
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
   integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/context@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.0.tgz#be88e22c0ddf62aeb0ae9f95c3d90932c619a5c8"
+  integrity sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==
   dependencies:
     tslib "^2.3.0"
 
@@ -7871,6 +7897,11 @@ resolve@^1.1.6, resolve@^1.20.0:
     is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+response-iterator@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/response-iterator/-/response-iterator-0.2.6.tgz#249005fb14d2e4eeb478a3f735a28fd8b4c9f3da"
+  integrity sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

There has an issue when using the `network-clients` SDK in nodeJS project. 

```
Error: Cannot find module 'react'
Require stack:
- /Users/mz/Projects/Subquery/indexer-excellent-program/node_modules/@apollo/client/react/context/context.cjs
```

Need to import all the items from `@apollo/client/core` other than `@apollo/client`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Update apollo imports from `@apollo/client/core` other than `@apollo/client`.
- This should fix the relate issue in `network-clients` and `apollo-links`

