### PR TITLE
Add `graphql` as peer dependency in auth link lib

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -83,7 +83,7 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump apollo-links & deploy
-        # if: steps.changed-apollo-links.outputs.changed == 'true'
+        if: steps.changed-apollo-links.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/apollo-links

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-prettier": "^4.0.0",
     "flag": "^5.0.1",
+    "graphql": "^16.5.0",
     "graphql-language-service-server": "^2.8.9",
     "husky": "^8.0.1",
     "ipfs-http-client": "^53.0.1",

--- a/packages/apollo-links/package.json
+++ b/packages/apollo-links/package.json
@@ -14,7 +14,6 @@
     "axios": "^0.27.2",
     "buffer": "^6.0.3",
     "ethers": "^5.6.8",
-    "graphql": "^16.5.0",
     "jwt-decode": "^3.1.2"
   },
   "devDependencies": {
@@ -22,8 +21,7 @@
     "typescript": "^4.6.4"
   },
   "peerDependencies": {
-    "@subql/contract-sdk": "^0.10.2-22",
-    "ipfs-http-client": "^53.0.1"
+    "graphql": "*"
   },
   "stableVersion": "0.2.1-6"
 }

--- a/packages/apollo-links/src/auth-link/authLink.ts
+++ b/packages/apollo-links/src/auth-link/authLink.ts
@@ -29,7 +29,6 @@ export class AuthLink extends ApolloLink {
     return new Observable<FetchResult>(observer => {
       let sub: Subscription;
       this.requestToken().then((token) => {
-        console.log(token);
         operation.setContext({ headers: { authorization: `Bearer ${token}` } }); 
         sub = forward(operation).subscribe(observer);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,12 +2998,10 @@ __metadata:
     axios: ^0.27.2
     buffer: ^6.0.3
     ethers: ^5.6.8
-    graphql: ^16.5.0
     jwt-decode: ^3.1.2
     typescript: ^4.6.4
   peerDependencies:
-    "@subql/contract-sdk": ^0.10.2-22
-    ipfs-http-client: ^53.0.1
+    graphql: "*"
   languageName: unknown
   linkType: soft
 
@@ -3038,6 +3036,7 @@ __metadata:
     eslint-plugin-header: ^3.1.1
     eslint-plugin-prettier: ^4.0.0
     flag: ^5.0.1
+    graphql: ^16.5.0
     graphql-language-service-server: ^2.8.9
     husky: ^8.0.1
     ipfs-http-client: ^53.0.1


### PR DESCRIPTION
## Description

Set `graphql`  as peer dependency in `AuthLink` lib, it can resolve the issues for version conflicts on client side.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Clean codes in authlink
- Set graphql as peer dependency
