### PR TITLE
Change the order of publish package

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -60,18 +60,18 @@ jobs:
       - name: build
         run: yarn build
 
-      - name: Bump network-clients & deploy
-        if: steps.changed-network-clients.outputs.changed == 'true'
-        uses: ./.github/actions/create-prerelease
-        with:
-          package-path: packages/network-clients
-          npm-token: ${{ secrets.NPM_TOKEN }}
-
       - name: Bump network-query & deploy
         if: steps.changed-network-query.outputs.changed == 'true'
         uses: ./.github/actions/create-prerelease
         with:
           package-path: packages/network-query
+          npm-token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Bump network-clients & deploy
+        if: steps.changed-network-clients.outputs.changed == 'true'
+        uses: ./.github/actions/create-prerelease
+        with:
+          package-path: packages/network-clients
           npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump react-hooks & deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,19 +62,19 @@ jobs:
         run: yarn build
 
       #Publish to npm and github releases
-      - name: Publish network-clients
-        if: steps.changed-network-clients.outputs.changed == 'true'
-        uses: ./.github/actions/create-release
-        with:
-          package-path: packages/network-clients
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish network-query
         if: steps.changed-network-query.outputs.changed == 'true'
         uses: ./.github/actions/create-release
         with:
           package-path: packages/network-query
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish network-clients
+        if: steps.changed-network-clients.outputs.changed == 'true'
+        uses: ./.github/actions/create-release
+        with:
+          package-path: packages/network-clients
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Description

Change the order of publish client and query SDK, as the client sdk dependent on query sdk, need to publish query sdk first before publish client sdk

Fixes # (issue)  Ticket # (ticket number)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
