### PR TITLE
separate the link create function for dict & project

### DIFF
--- a/packages/apollo-links/src/authHttpLink.ts
+++ b/packages/apollo-links/src/authHttpLink.ts
@@ -11,15 +11,27 @@ import { retryLink } from './retryLink';
 import { Logger, silentLogger } from './logger';
 import { FallbackLink } from './fallbackLink';
 
-interface AuthHttpOptions {
+interface DictAuthOptions extends BaseAuthOptions{
+  chainId: string // chain id for the requested dictionary
+}
+
+interface ProjectAuthOptions extends BaseAuthOptions {
+  projectId: string;           // deployment id
+}
+
+interface BaseAuthOptions {
   authUrl: string;             // auth service url
-  projectId: string;           // project chain id or depployment id
   httpOptions: HttpOptions;    // http options for init `HttpLink`
   logger?: Logger              // logger for `AuthLink`
   fallbackServiceUrl?: string; // fall back service url for `AuthLink`
 }
 
-export function authHttpLink(options: AuthHttpOptions): ApolloLink {
+export function dictHttpLink(options: DictAuthOptions): ApolloLink {
+  const { chainId} = options;
+  return projectHttpLink({...options, projectId: chainId});
+}
+
+export function projectHttpLink(options: ProjectAuthOptions): ApolloLink {
   const { projectId, httpOptions, fallbackServiceUrl, authUrl, logger: _logger } = options;
 
   const logger = _logger ?? silentLogger();

--- a/test/authLink.test.ts
+++ b/test/authLink.test.ts
@@ -9,7 +9,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-import { authHttpLink, AuthLink } from '../packages/apollo-links/src';
+import { dictHttpLink, AuthLink } from '../packages/apollo-links/src';
 
 // TODO: need fix the test cases
 const logger = Pino({ level: 'debug' });
@@ -61,11 +61,11 @@ describe('auth link with auth center', () => {
 
   beforeAll(async () => {
     const authUrl = process.env.AUTH_URL ?? '';
-    const projectId = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
+    const chainId = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
     const fallbackServiceUrl = "https://api.subquery.network/sq/subquery/polkadot-dictionary";
     const httpOptions = { fetch, fetchOptions: { timeout: 3000 } };
-    const options = { authUrl, projectId, httpOptions, fallbackServiceUrl, logger }
-    const link = authHttpLink(options);
+    const options = { authUrl, chainId, httpOptions, fallbackServiceUrl, logger }
+    const link = dictHttpLink(options);
 
     client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -83,5 +83,5 @@ describe('auth link with auth center', () => {
     for (let i = 0; i < count; i++) {
       await expect(client.query({ query: metadataQuery })).resolves.toBeTruthy();
     }
-  });
+  },20000);
 });


### PR DESCRIPTION
## Description
Split `authHttpLink()` into `dictHttpLink` & `projectHttpLink`

for the reason
* make it clear in which scenario which one should be used
* both of them only make sense when use with an auth service, but not the case when passing pk directly. 
* for pk case, we can use a different entry method

Fixes # (issue)  Ticket # (ticket number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

- First change
- Second change
- etc
