### PR TITLE
feat: add filter for get indexers and reset testnet config

### DIFF
--- a/packages/network-config/src/constants.ts
+++ b/packages/network-config/src/constants.ts
@@ -28,7 +28,7 @@ export const RPC_ENDPOINTS = {
 export const NETWORK_SUBQL_ENDPOINTS = {
   mainnet: 'https://api.subquery.network/sq/subquery/kepler-network',
   kepler: 'https://api.subquery.network/sq/subquery/kepler-network',
-  testnet: 'https://api.subquery.network/sq/subquery/kepler-network',
+  testnet: 'https://api.subquery.network/sq/subquery/kepler-testnet',
 };
 
 export const AIRDROP_SUBQL_ENDPOINTS = {

--- a/packages/network-query/queries/network/indexers.gql
+++ b/packages/network-query/queries/network/indexers.gql
@@ -17,13 +17,13 @@ query GetIndexer($address: String!) {
   }
 }
 
-query GetIndexers($first: Int, $offset: Int, $order: IndexersOrderBy = ID_ASC) {
-  indexers(
-    first: $first
-    offset: $offset
-    orderBy: [$order]
-    filter: { active: { equalTo: true } }
-  ) {
+query GetIndexers(
+  $first: Int
+  $offset: Int
+  $order: IndexersOrderBy = ID_ASC
+  $filter: IndexerFilter = { active: { equalTo: true } }
+) {
+  indexers(first: $first, offset: $offset, orderBy: [$order], filter: $filter) {
     totalCount
     pageInfo {
       startCursor

--- a/packages/network-query/types.codegen.ts
+++ b/packages/network-query/types.codegen.ts
@@ -14,7 +14,12 @@ const config: CodegenConfig = {
   config: {
     preResolveTypes: true,
     namingConvention: 'keep',
-    avoidOptionals: true,
+    avoidOptionals: {
+      field: true,
+      object: false,
+      inputValue: false,
+      defaultValue: false,
+    },
     nonOptionalTypename: true,
     skipTypeNameForRoot: true,
     immutableTypes: true,

--- a/test/networkClient.test.ts
+++ b/test/networkClient.test.ts
@@ -3,9 +3,7 @@
 
 import { NetworkClient, SQNetworks } from '../packages/network-clients/src';
 
-// TODO: reset
-// const TEST_INDEXER = '0xCef192586b70e3Fc2FAD76Dd1D77983a30d38D04';
-const TEST_INDEXER = '0x33b8D680e49145Bac668991f9A8e0f7681f72858';
+const TEST_INDEXER = '0xCef192586b70e3Fc2FAD76Dd1D77983a30d38D04';
 
 describe.only('network client', () => {
   let client: NetworkClient;


### PR DESCRIPTION
## Description

- Add filter for `GetIndexers`.
- Change `avoidOptionals` to false on some cases, that will generated some type like `type p = { xxx?: string }` rather than `type p = { xxx: string }`. So when clients use `filter` on some query would not be fill all the fields of `filter` 
- Reset network subql endpoint of testnet, that will fix `unstake` problem and something relative `getIndex` function.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
