### PR TITLE
feat: support custom apollo clients

### DIFF
--- a/packages/network-clients/src/clients/networkClient.ts
+++ b/packages/network-clients/src/clients/networkClient.ts
@@ -28,14 +28,21 @@ export class NetworkClient {
     this._contractClient = new ContractClient(_sdk);
   }
 
-  public static create(network: SQNetworks, provider?: Provider, ipfsUrl?: string) {
+  public static create(
+    network: SQNetworks,
+    provider?: Provider,
+    ipfsUrl?: string,
+    options?: {
+      queryClient?: GraphqlQueryClient;
+    }
+  ) {
     const config = NETWORK_CONFIGS[network];
     assert(config, `config for ${network} is missing`);
     const sdk = ContractSDK.create(
       provider ?? new providers.StaticJsonRpcProvider(config.defaultEndpoint),
       config.sdkOptions
     );
-    const gqlClient = new GraphqlQueryClient(config);
+    const gqlClient = options?.queryClient ? options?.queryClient : new GraphqlQueryClient(config);
     return new NetworkClient(sdk, gqlClient, ipfsUrl);
   }
 
@@ -135,5 +142,9 @@ export class NetworkClient {
     if (!isCID(cid)) throw new Error(`Invalid cid: ${cid}`);
     // get project metadata
     // cat project metadata
+  }
+
+  public setGqlClient(gqlClient: GraphqlQueryClient) {
+    this._gqlClient = gqlClient;
   }
 }

--- a/packages/network-clients/src/clients/networkClient.ts
+++ b/packages/network-clients/src/clients/networkClient.ts
@@ -16,6 +16,7 @@ import assert from 'assert';
 import { Indexer } from '../models/indexer';
 import { parseRawEraValue } from '../utils/parseEraValue';
 import { SQNetworks } from '@subql/network-config';
+import { ApolloClient, ApolloClientOptions, NormalizedCacheObject } from '@apollo/client/core';
 
 type Provider = AbstractProvider | Signer;
 
@@ -33,7 +34,9 @@ export class NetworkClient {
     provider?: Provider,
     ipfsUrl?: string,
     options?: {
-      queryClient?: GraphqlQueryClient;
+      queryClientOptions?:
+        | ApolloClient<NormalizedCacheObject>
+        | ApolloClientOptions<NormalizedCacheObject>;
     }
   ) {
     const config = NETWORK_CONFIGS[network];
@@ -42,7 +45,7 @@ export class NetworkClient {
       provider ?? new providers.StaticJsonRpcProvider(config.defaultEndpoint),
       config.sdkOptions
     );
-    const gqlClient = options?.queryClient ? options?.queryClient : new GraphqlQueryClient(config);
+    const gqlClient = new GraphqlQueryClient(config, options?.queryClientOptions);
     return new NetworkClient(sdk, gqlClient, ipfsUrl);
   }
 

--- a/packages/network-clients/src/clients/queryClient.ts
+++ b/packages/network-clients/src/clients/queryClient.ts
@@ -1,7 +1,13 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client/core';
+import {
+  ApolloClient,
+  ApolloClientOptions,
+  HttpLink,
+  InMemoryCache,
+  NormalizedCacheObject,
+} from '@apollo/client/core';
 import fetch from 'cross-fetch';
 import {
   GetDelegation,
@@ -29,19 +35,29 @@ export class GraphqlQueryClient {
     return this.apolloClients[GQLEndpoint.Network];
   }
 
-  constructor(private config: NetworkConfig) {
-    this.apolloClients[GQLEndpoint.Network] = new ApolloClient({
-      cache: new InMemoryCache({ resultCaching: true }),
-      link: new HttpLink({ uri: config.gql.network, fetch: fetch }),
-      defaultOptions: {
-        watchQuery: {
-          fetchPolicy: 'no-cache',
+  constructor(config: NetworkConfig, apolloClient?: ApolloClient<NormalizedCacheObject>);
+  constructor(
+    private config: NetworkConfig,
+    apolloClientOptionsOrClient?: ApolloClientOptions<NormalizedCacheObject>
+  ) {
+    if (apolloClientOptionsOrClient instanceof ApolloClient) {
+      this.apolloClients[GQLEndpoint.Network] = apolloClientOptionsOrClient;
+    } else {
+      this.apolloClients[GQLEndpoint.Network] = new ApolloClient({
+        cache: new InMemoryCache({ resultCaching: true }),
+        link: new HttpLink({ uri: config.gql.network, fetch: fetch }),
+        defaultOptions: {
+          watchQuery: {
+            fetchPolicy: 'no-cache',
+          },
+          query: {
+            fetchPolicy: 'no-cache',
+          },
         },
-        query: {
-          fetchPolicy: 'no-cache',
-        },
-      },
-    });
+
+        ...apolloClientOptionsOrClient,
+      });
+    }
   }
 
   // QUERY REGISTRY QUERY FUNCTIONS

--- a/packages/network-clients/src/clients/queryClient.ts
+++ b/packages/network-clients/src/clients/queryClient.ts
@@ -35,10 +35,11 @@ export class GraphqlQueryClient {
     return this.apolloClients[GQLEndpoint.Network];
   }
 
-  constructor(config: NetworkConfig, apolloClient?: ApolloClient<NormalizedCacheObject>);
   constructor(
     private config: NetworkConfig,
-    apolloClientOptionsOrClient?: ApolloClientOptions<NormalizedCacheObject>
+    apolloClientOptionsOrClient?:
+      | ApolloClientOptions<NormalizedCacheObject>
+      | ApolloClient<NormalizedCacheObject>
   ) {
     if (apolloClientOptionsOrClient instanceof ApolloClient) {
       this.apolloClients[GQLEndpoint.Network] = apolloClientOptionsOrClient;


### PR DESCRIPTION
## Description

- `GraphqlQueryClient` can accept the second arg that type could be `ApolloClient` or `ApolloClientOptions`.
- `NetworkClient` add a public method for set `_gqlClient`. 

Ticket # [SQN-1671](https://onfinality.atlassian.net/browse/SQN-1671)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Test on Browser

### fallback

![SCR-20230719-kvwo](https://github.com/subquery/network-clients/assets/10172415/bff4025c-9616-411c-ae5e-64e5a1a761f8)

### custom gqlClient

![SCR-20230719-kuxq](https://github.com/subquery/network-clients/assets/10172415/943abf4f-628d-4f8a-b6cb-becdf0c6fd46)

