### PR TITLE
fix: consuming cached token

### DIFF
--- a/packages/apollo-links/src/utils/orderManager.ts
+++ b/packages/apollo-links/src/utils/orderManager.ts
@@ -1,9 +1,9 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { Agreement, OrderType, Plan, ProjectType } from '../types';
 import { Logger } from './logger';
 import { fetchOrders } from './query';
-import { Agreement, ProjectType, Plan, OrderType } from '../types';
 
 type Options = {
   logger: Logger;


### PR DESCRIPTION
## Changes

- Fix consuming cached token

## Test cases

- Set fixed 2 available agreement for polkadot dictionary (From Kepler), sending 20 queries request. Here are the test logs

```
    request new token for indexer 0xa8ddFCf5b5aC088d4d9DaA76fE8b743351578399
    request new token for indexer 0xa8ddFCf5b5aC088d4d9DaA76fE8b743351578399 success
    use url: https://subquery-indexer.liveraven.net/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    request new token for indexer 0xf6A7FddeB551b8a8C5cc57D9c0Ebc14ce34ce401
    request new token for indexer 0xf6A7FddeB551b8a8C5cc57D9c0Ebc14ce34ce401 success
    use url: http://66.206.2.162/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: https://subquery-indexer.liveraven.net/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: https://subquery-indexer.liveraven.net/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: http://66.206.2.162/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: https://subquery-indexer.liveraven.net/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: https://subquery-indexer.liveraven.net/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: http://66.206.2.162/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: https://subquery-indexer.liveraven.net/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: https://subquery-indexer.liveraven.net/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    use url: http://66.206.2.162/query/QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm
    ...
```