### PR TITLE
[Release] @subql/apollo-links@1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "devDependencies": {
     "@actions/core": "^1.9.1",
-    "@apollo/client": "^3.7.0",
+    "@apollo/client": "^3.8.8",
     "@metamask/eth-sig-util": "^4.0.1",
     "@octokit/request": "^5.6.3",
     "@subql/contract-sdk": "^0.16.2",

--- a/packages/apollo-links/CHANGELOG.md
+++ b/packages/apollo-links/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2023-12-21
+
 ## [1.2.3] - 2023-11-27
 
 ## [1.2.2] - 2023-11-13
@@ -86,7 +88,8 @@ Breaking change for `dictHttpLink` and `deploymentHttpLink`, use `const { link }
 
 - Add Authlink for Apollo client
 
-[unreleased]: https://github.com/subquery/network-clients/compare/v1.2.3...HEAD
+[unreleased]: https://github.com/subquery/network-clients/compare/v1.2.4...HEAD
+[1.2.4]: https://github.com/subquery/network-clients/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/subquery/network-clients/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/subquery/network-clients/compare/v1.1.0...v1.2.2
 [1.1.0]: https://github.com/subquery/network-clients/compare/v1.0.8...v1.1.0

--- a/packages/apollo-links/package.json
+++ b/packages/apollo-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/apollo-links",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "SubQuery Network - graphql links",
   "main": "dist/index.js",
   "author": "SubQuery Pte Limited",

--- a/packages/apollo-links/package.json
+++ b/packages/apollo-links/package.json
@@ -2,7 +2,7 @@
   "name": "@subql/apollo-links",
   "version": "1.2.4",
   "description": "SubQuery Network - graphql links",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "author": "SubQuery Pte Limited",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/apollo-links/package.json
+++ b/packages/apollo-links/package.json
@@ -2,7 +2,7 @@
   "name": "@subql/apollo-links",
   "version": "1.2.4",
   "description": "SubQuery Network - graphql links",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "author": "SubQuery Pte Limited",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/apollo-links/src/core/clusterAuthLink.ts
+++ b/packages/apollo-links/src/core/clusterAuthLink.ts
@@ -41,11 +41,19 @@ export class ClusterAuthLink extends ApolloLink {
             sub = forward(operation).subscribe(observer);
           } else {
             this.logger?.debug('no available orders');
+            // For handling if one indexer's score is not enough for reduce retries times
+            // e.g indexer have 10 score, when first failed, the score is reach to 0,
+            // but because at above code set the url & indexer. retryLink also believe it's a
+            // valid url. so re-try again.
+            // set url is null-string can enter fallbackLink to handle if use fallback link
+            // otherwise would re-try until reach the max retires.
+            operation.setContext({ url: '' });
             sub = forward(operation).subscribe(observer);
           }
         })
         .catch((error) => {
           if (error.indexer) {
+            console.warn(456);
             this.logger?.debug(`Failed to get token: ${String(error.message)}`);
             operation.setContext({ indexer: error.indexer });
             observer.error(new Error('failed to get indexer request params'));

--- a/packages/apollo-links/src/core/clusterAuthLink.ts
+++ b/packages/apollo-links/src/core/clusterAuthLink.ts
@@ -53,7 +53,6 @@ export class ClusterAuthLink extends ApolloLink {
         })
         .catch((error) => {
           if (error.indexer) {
-            console.warn(456);
             this.logger?.debug(`Failed to get token: ${String(error.message)}`);
             operation.setContext({ indexer: error.indexer });
             observer.error(new Error('failed to get indexer request params'));

--- a/packages/apollo-links/src/core/responseLink.ts
+++ b/packages/apollo-links/src/core/responseLink.ts
@@ -54,6 +54,10 @@ export class ResponseLink extends ApolloLink {
                     Base64.decode(responseHeaders.get('X-Channel-State')).toString()
                   ) as ChannelState)
                 : response.state;
+
+              if (!channelState) {
+                this.logger?.debug("Can't find the channel state information");
+              }
               void this.syncChannelState(channelState);
             }
           }

--- a/packages/network-support/package.json
+++ b/packages/network-support/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@subql/network-support",
   "version": "0.1.0",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "author": "SubQuery Pte Limited",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/network-support/package.json
+++ b/packages/network-support/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@subql/network-support",
   "version": "0.1.0",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "author": "SubQuery Pte Limited",
   "license": "Apache-2.0",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/client@npm:^3.8.8":
+  version: 3.8.8
+  resolution: "@apollo/client@npm:3.8.8"
+  dependencies:
+    "@graphql-typed-document-node/core": ^3.1.1
+    "@wry/equality": ^0.5.6
+    "@wry/trie": ^0.5.0
+    graphql-tag: ^2.12.6
+    hoist-non-react-statics: ^3.3.2
+    optimism: ^0.18.0
+    prop-types: ^15.7.2
+    response-iterator: ^0.2.6
+    symbol-observable: ^4.0.0
+    ts-invariant: ^0.10.3
+    tslib: ^2.3.0
+    zen-observable-ts: ^1.2.5
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    graphql-ws: ^5.5.5
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+  peerDependenciesMeta:
+    graphql-ws:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+    subscriptions-transport-ws:
+      optional: true
+  checksum: df01412424b61f0b102b8453dfc611d7a2bdae6921fed31700196939076f1c6774eb942dc52bf6dc3f7212280dc0748998b243e09f60b889d989d9a1f08f30b3
+  languageName: node
+  linkType: hard
+
 "@apollo/federation@npm:0.27.0":
   version: 0.27.0
   resolution: "@apollo/federation@npm:0.27.0"
@@ -3335,7 +3370,7 @@ __metadata:
   resolution: "@subql/network-tools@workspace:."
   dependencies:
     "@actions/core": ^1.9.1
-    "@apollo/client": ^3.7.0
+    "@apollo/client": ^3.8.8
     "@metamask/eth-sig-util": ^4.0.1
     "@octokit/request": ^5.6.3
     "@subql/contract-sdk": ^0.16.2
@@ -3993,6 +4028,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wry/caches@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@wry/caches@npm:1.0.1"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 9e89aa8e9e08577b2e4acbe805f406b141ae49c2ac4a2e22acf21fbee68339fa0550e0dee28cf2158799f35bb812326e80212e49e2afd169f39f02ad56ae4ef4
+  languageName: node
+  linkType: hard
+
 "@wry/context@npm:^0.6.0":
   version: 0.6.1
   resolution: "@wry/context@npm:0.6.1"
@@ -4029,12 +4073,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wry/equality@npm:^0.5.6":
+  version: 0.5.7
+  resolution: "@wry/equality@npm:0.5.7"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 892f262fae362df80f199b12658ea6966949539d4a3a50c1acf00d94a367d673a38f8efa1abcb726ae9e5cc5e62fce50c540c70f797b7c8a2c4308b401dfd903
+  languageName: node
+  linkType: hard
+
 "@wry/trie@npm:^0.3.0":
   version: 0.3.2
   resolution: "@wry/trie@npm:0.3.2"
   dependencies:
     tslib: ^2.3.0
   checksum: 151d06b519e1ff1c3acf6ee6846161b1d7d50bbecd4c48e5cd1b05f9e37c30602aff02e88f20105f6e6c54ae4123f9c4eb7715044d7fd927d4ba4ec3e755cd36
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "@wry/trie@npm:0.4.3"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 106e021125cfafd22250a6631a0438a6a3debae7bd73f6db87fe42aa0757fe67693db0dfbe200ae1f60ba608c3e09ddb8a4e2b3527d56ed0a7e02aa0ee4c94e1
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wry/trie@npm:0.5.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 92aeea34152bd8485184236fe328d3d05fc98ee3b431d82ee60cf3584dbf68155419c3d65d0ff3731b204ee79c149440a9b7672784a545afddc8d4342fbf21c9
   languageName: node
   linkType: hard
 
@@ -11525,6 +11596,18 @@ __metadata:
     "@wry/context": ^0.6.0
     "@wry/trie": ^0.3.0
   checksum: 7506a3e5e37b8945059ffacd68039e920ad121aab3eeff27483b7a8b594f6f694f2a3b61a198aeecc43b81753d35c8cb32b7f662d2b5e2d2449fe7068da678e1
+  languageName: node
+  linkType: hard
+
+"optimism@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "optimism@npm:0.18.0"
+  dependencies:
+    "@wry/caches": ^1.0.0
+    "@wry/context": ^0.7.0
+    "@wry/trie": ^0.4.3
+    tslib: ^2.3.0
+  checksum: d6ed6a90b05ee886dadfe556c7a30227c66843f51278e51eb843977a6a9368b6c50297fcc63fa514f53d8a5a58f8ddc8049c2356bd4ffac32f8961bcb806254d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- apollo-client 3.7.0 doesn't handle the abort error, upgrade to 3.8.8.
- Fix an unexpected behavior when indexer not enough score to re-try.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

