### PR TITLE
Add fun to `getIndexerMetadata` only

### DIFF
--- a/packages/network-clients/src/clients/networkClient.ts
+++ b/packages/network-clients/src/clients/networkClient.ts
@@ -13,7 +13,7 @@ import { GraphqlQueryClient } from './queryClient';
 import { isCID, min } from '../utils';
 import { DEFAULT_IPFS_URL, NETWORK_CONFIGS } from '@subql/network-config';
 import assert from 'assert';
-import { Indexer } from '../models/indexer';
+import { Indexer, IndexerMetadata } from '../models/indexer';
 import { parseRawEraValue } from '../utils/parseEraValue';
 import { SQNetworks } from '@subql/network-config';
 import { ApolloClient, ApolloClientOptions, NormalizedCacheObject } from '@apollo/client/core';
@@ -99,6 +99,18 @@ export class NetworkClient {
       delegated,
       capacity,
     };
+  }
+
+  public async getIndexerMetadata(address: string): Promise<IndexerMetadata | undefined> {
+    const indexer = await this._gqlClient.getIndexer(address);
+    if (!indexer) return;
+    const { metadata: metadatCID } = indexer;
+    const metadata = await this._ipfs.getJSON<{
+      name: string;
+      url: string;
+    }>(metadatCID);
+
+    return metadata;
   }
 
   public async maxUnstakeAmount(address: string): Promise<BigNumber> {

--- a/test/networkClient.test.ts
+++ b/test/networkClient.test.ts
@@ -1,14 +1,12 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { SQNetworks } from '@subql/network-config';
+import { SQNetworks } from '../packages/network-config/src';
 import { NetworkClient } from '../packages/network-clients/src';
 
 const TEST_INDEXER = '0xCef192586b70e3Fc2FAD76Dd1D77983a30d38D04';
 
-// testnet have change, skip for now
-// FIXME
-describe.skip('network client', () => {
+describe('network client', () => {
   let client: NetworkClient;
   beforeAll(() => {
     client = NetworkClient.create(SQNetworks.TESTNET);

--- a/test/networkClient.test.ts
+++ b/test/networkClient.test.ts
@@ -4,7 +4,7 @@
 import { SQNetworks } from '@subql/network-config';
 import { NetworkClient } from '../packages/network-clients/src';
 
-const TEST_INDEXER = '0xFCA0037391B3cfe28f17453D6DBc4A7618F771e1';
+const TEST_INDEXER = '0xCef192586b70e3Fc2FAD76Dd1D77983a30d38D04';
 
 // testnet have change, skip for now
 // FIXME
@@ -17,6 +17,12 @@ describe.skip('network client', () => {
   it('can get indexer detail', async () => {
     const indexer = await client.getIndexer(TEST_INDEXER);
     expect(indexer?.metadata).toBeTruthy();
+  });
+
+  it('can get indexer metadata', async () => {
+    const metadata = await client.getIndexerMetadata(TEST_INDEXER);
+    expect(metadata?.name).toBeTruthy();
+    expect(metadata?.url).toBeTruthy();
   });
 
   it('can get delegating value', async () => {


### PR DESCRIPTION
## Description

Add new function `getIndexerMetadata` in client SDK, this function is helpful in some service projects to get the indexerMetadata only and ignore the other request in `getIndexer` function.
