### PR TITLE
Remove and clean up network-clients package dependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,21 +9,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Node.js environment
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16
-    - run: yarn
+      - uses: actions/checkout@v2
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: 22
+      - run: yarn
 
-    - name: build
-      run: yarn build
+      - name: build
+        run: yarn build
 
-    - name: lint
-      run: yarn lint
+      - name: lint
+        run: yarn lint
 
-    - name: test
-      run: yarn test --forceExit
-      env:
-        AUTH_URL: ${{ vars.AUTH_URL }}
-
+      - name: test
+        run: yarn test --forceExit
+        env:
+          AUTH_URL: ${{ vars.AUTH_URL }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 22
 
       - uses: marceloprado/has-changed-path@v1
         id: changed-network-config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 22
 
       #Identify changes
       - uses: marceloprado/has-changed-path@v1

--- a/packages/network-clients/CHANGELOG.md
+++ b/packages/network-clients/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Unused `axios`, `cross-fetch` and `buffer` dependencies (#365)
 
 ## [1.1.0] - 2024-02-21
 

--- a/packages/network-clients/package.json
+++ b/packages/network-clients/package.json
@@ -12,9 +12,6 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@subql/network-config": "workspace:*",
     "@subql/network-query": "workspace:*",
-    "axios": "^0.27.2",
-    "buffer": "^6.0.3",
-    "cross-fetch": "^3.1.5",
     "ethers": "^5.6.8",
     "graphql": "^16.5.0"
   },

--- a/packages/network-clients/src/clients/ipfsClient.ts
+++ b/packages/network-clients/src/clients/ipfsClient.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import buffer from 'buffer';
+import buffer from 'node:buffer';
 import { IPFSHTTPClient, create } from 'ipfs-http-client';
 import { concatU8A, isCID } from '../utils';
 

--- a/packages/network-clients/src/clients/ipfsClient.ts
+++ b/packages/network-clients/src/clients/ipfsClient.ts
@@ -1,11 +1,9 @@
 // Copyright 2020-2022 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import buffer from 'node:buffer';
+import { Buffer } from 'node:buffer';
 import { IPFSHTTPClient, create } from 'ipfs-http-client';
 import { concatU8A, isCID } from '../utils';
-
-const Buffer = buffer.Buffer;
 
 export class IPFSClient {
   private _client: IPFSHTTPClient;

--- a/packages/network-clients/src/clients/queryClient.ts
+++ b/packages/network-clients/src/clients/queryClient.ts
@@ -8,7 +8,6 @@ import {
   InMemoryCache,
   NormalizedCacheObject,
 } from '@apollo/client/core';
-import fetch from 'cross-fetch';
 import {
   GetDelegation,
   GetDelegationQuery,

--- a/packages/network-clients/src/utils/ipfs.ts
+++ b/packages/network-clients/src/utils/ipfs.ts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { utils } from 'ethers';
-import buffer from 'buffer';
-
-const Buffer = buffer.Buffer;
+import { Buffer } from 'node:buffer';
 
 export const CIDv0 = new RegExp(/Qm[1-9A-HJ-NP-Za-km-z]{44}/i);
 export const CIDv1 = new RegExp(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3230,10 +3230,7 @@ __metadata:
     "@subql/network-config": "workspace:*"
     "@subql/network-query": "workspace:*"
     apollo: ^2.34.0
-    axios: ^0.27.2
-    buffer: ^6.0.3
     create-ts-index: ^1.14.0
-    cross-fetch: ^3.1.5
     ethers: ^5.6.8
     graphql: ^16.5.0
     typescript: ^4.6.4


### PR DESCRIPTION
## Description
- Primarily removes unused `axios` dependency from `@subql/network-clients` package because of security warnings.
- Also removes `cross-fetch` in favour of built in `fetch` and swaps `buffer` for nodejs built in `buffer`.
- Updates CI from Nodejs 16 to 22, the current LTS version


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


